### PR TITLE
Fix template translation font-size controls

### DIFF
--- a/Matsuri_translation/frontend/api3.js
+++ b/Matsuri_translation/frontend/api3.js
@@ -584,10 +584,10 @@
     return card;
   }
 
-  function safeTemplateHtml(template, translation) {
+  function safeTemplateHtml(template, translation, fontSize) {
     const escaped = document.createElement("div");
     escaped.textContent = translation;
-    const translationHtml = escaped.innerHTML.replace(/\n/g, "<br>");
+    const translationHtml = `<span class="template-translation-text" style="font-size:${fontSize}px">${escaped.innerHTML.replace(/\n/g, "<br>")}</span>`;
     const parsed = document.createElement("template");
     parsed.innerHTML = template.replaceAll("{T}", translationHtml);
     const allowedTags = new Set(["DIV", "SPAN", "P", "BR", "IMG", "STRONG", "EM", "B", "I", "SMALL", "H1", "H2", "H3", "H4", "H5", "H6", "UL", "OL", "LI", "TABLE", "THEAD", "TBODY", "TR", "TD", "TH"]);
@@ -632,7 +632,7 @@
     if (state.template.trim()) {
       const variants = templateVariants(state.template);
       const variantIndex = state.botMode && index !== state.focalIndex && variants[1] ? 1 : 0;
-      block.append(safeTemplateHtml(variants[variantIndex], text));
+      block.append(safeTemplateHtml(variants[variantIndex], text, state.fontSize));
       return block;
     }
     const logo = logoSource();

--- a/test/e2e.test.mjs
+++ b/test/e2e.test.mjs
@@ -105,6 +105,11 @@ test("browser editor and bot renderer share the working export surface", { timeo
     const restoredTranslation = page.getByPlaceholder("输入中文翻译（留空则只显示原文）").first();
     await restoredTranslation.waitFor();
     await restoredTranslation.fill("虽然麻烦不断，直播还是开始了！");
+    const templatedTranslation = page.locator("#capture .template-translation-text").first();
+    await page.locator("#font-size-select").selectOption("30");
+    assert.equal(await templatedTranslation.evaluate((node) => getComputedStyle(node).fontSize), "30px");
+    await page.locator("#font-size-select").selectOption("23");
+    assert.equal(await templatedTranslation.evaluate((node) => getComputedStyle(node).fontSize), "23px");
     const builtinLogoDimensions = await page.locator("#capture .translation-block img").first().evaluate((image) => ({
       width: image.getBoundingClientRect().width,
       naturalWidth: image.naturalWidth

--- a/test/template-render.test.mjs
+++ b/test/template-render.test.mjs
@@ -32,6 +32,7 @@ test("every bundled template renders its real logo without distortion or overflo
         translate: "模板实际渲染测试",
         template,
         logo: "none",
+        fontSize: 30,
         noLikes: true
       }), { data: normalizedTweet(), template });
       const result = await page.locator("#capture .translation-block").evaluate((block) => {
@@ -46,10 +47,13 @@ test("every bundled template renders its real logo without distortion or overflo
           images,
           clientWidth: block.clientWidth,
           scrollWidth: block.scrollWidth,
-          text: block.textContent
+          text: block.textContent,
+          translationFontSizes: [...block.querySelectorAll(".template-translation-text")]
+            .map((node) => getComputedStyle(node).fontSize)
         };
       });
       assert.match(result.text, /模板实际渲染测试/, `${item.file}: translation is missing`);
+      assert.deepEqual(result.translationFontSizes, ["30px"], `${item.file}: selected translation font size was ignored`);
       assert.ok(result.images.length > 0, `${item.file}: logo is missing`);
       assert.ok(result.scrollWidth <= result.clientWidth, `${item.file}: content overflows the 640px export surface`);
       for (const image of result.images) {


### PR DESCRIPTION
## Summary

- make the translation font-size selector override the text inserted at each template {T} placeholder
- keep template structure, logo dimensions, and tweet typography unchanged
- cover both editor interaction and every bundled template in real Chromium

## Verification

- 23/23 tests pass
- all 51 bundled templates render at the selected 30px translation size
- browser QA: 26px -> 30px -> 23px changes computed text size while the same logo remains 360x38
- current public image ghcr.io/cn-matsuri/tweettoaster:latest anonymously resolves to the merged multi-arch digest sha256:8943b1d99662f6b791f650fac1c3ec61fe2df60024b83d61e673b332b178701a; no Docker workflow change is required